### PR TITLE
add feat: support custom gpt model

### DIFF
--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -1,4 +1,4 @@
 pref("extensions.zotero.__addonRef__.enable", true);
 pref("extensions.zotero.__addonRef__.tags", "[]");
 pref("extensions.zotero.__addonRef__.secretKey", "");
-
+pref("extensions.zotero.__addonRef__.model", "gpt-3.5-turbo");

--- a/src/modules/views.ts
+++ b/src/modules/views.ts
@@ -53,6 +53,7 @@ export default class Views {
 
   private async getGPTResponseText(requestText: string) {
     const secretKey = Zotero.Prefs.get(`${config.addonRef}.secretKey`)
+    const model = Zotero.Prefs.get(`${config.addonRef}.model`)
     const outputSpan = this.outputContainer!.querySelector("span")!
     let responseText = "";
     const xhr = await Zotero.HTTP.request(
@@ -64,7 +65,7 @@ export default class Views {
           "Authorization": `Bearer ${secretKey}`,
         },
         body: JSON.stringify({
-          model: "gpt-3.5-turbo",
+          model: model,
           messages: [{
             "role": "user", "content": requestText
           }],


### PR DESCRIPTION
增加用户自定义选择GPT模型的功能  

虽然GPT-4价格高了一些、速度略慢，但是输出质量相比GPT-3.5确实更好，值得切换  
[GPT-4 模型](https://platform.openai.com/docs/models/gpt-4)
[GPT-3.5 模型](https://platform.openai.com/docs/models/gpt-3-5)
[API 价格](https://openai.com/pricing)
