### PR TITLE
add feat: use markdown to show the result

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,15 +37,19 @@
   },
   "homepage": "https://github.com/MuiseDestiny/zotero-gpt#readme",
   "dependencies": {
+    "markdown-it": "^13.0.1",
+    "markdown-it-mathjax3": "^4.3.2",
     "zotero-plugin-toolkit": "^2.0.1"
   },
   "devDependencies": {
+    "@types/markdown-it": "^12.2.3",
     "@types/node": "^18.11.17",
     "compressing": "^1.6.3",
     "concurrently": "^7.6.0",
     "cross-env": "^7.0.3",
     "esbuild": "^0.17.4",
     "minimist": "^1.2.7",
+    "punycode": "^2.1.1",
     "release-it": "^15.6.0",
     "replace-in-file": "^6.3.5",
     "typescript": "^4.9.4",


### PR DESCRIPTION
#42

使用 [markdown-it](https://github.com/markdown-it/markdown-it) 和 [markdown-it-mathjax3](https://github.com/tani/markdown-it-mathjax3) 插件实现`markdown`和公式等的渲染   

[测试文件 zotero-gpt.xpi.zip ](https://github.com/MuiseDestiny/zotero-gpt/files/11182889/zotero-gpt.zip)

如图所示  
![1](https://user-images.githubusercontent.com/18099238/230713572-a1575742-61db-4252-8bbc-8018a56a24a8.png)

