### PR TITLE
add feat: zoom all elements without changing boundary

### DIFF
--- a/src/modules/views.ts
+++ b/src/modules/views.ts
@@ -529,6 +529,60 @@ export default class Views {
     })
   }
 
+  /**
+   * 绑定ctrl+滚轮放大缩小控件内的所有元素
+   * @param div
+   */
+  private bindCtrlScrollZoomOutput(div: HTMLDivElement) {
+    const styleAttributes = {
+      fontSize: 'font-size',
+      lineHeight: 'line-height',
+      marginBottom: 'margin-bottom',
+      marginTop: 'margin-top',
+      paddingBottom: 'padding-bottom',
+      paddingTop: 'padding-top',
+    } as const;
+    type StyleAttributeKeys = keyof typeof styleAttributes;
+    type StyleAttributes = {
+      [K in StyleAttributeKeys]: string;
+    };
+    // 获取子元素的初始样式
+    const getChildStyles = (child: Element): StyleAttributes => {
+      const style = window.getComputedStyle(child);
+      const result: Partial<StyleAttributes> = {};
+      for (const key in styleAttributes) {
+        const typedKey = key as StyleAttributeKeys;
+        result[typedKey] = style.getPropertyValue(styleAttributes[typedKey]);
+      }
+      return result as StyleAttributes;
+    };
+  
+    // 更新并应用子元素的样式
+    const applyNewStyles = (child: HTMLElement, style: StyleAttributes, scale: number) => {
+      const newStyle = (value: string) => parseFloat(value) * scale + 'px';
+  
+      for (const key in styleAttributes) {
+        child.style[key as StyleAttributeKeys] = newStyle(style[key as StyleAttributeKeys]);
+      }
+    };
+    // 为指定的div绑定wheel事件
+    div.addEventListener('DOMMouseScroll', (event: any) => {
+      const children = div.children[0].children;
+      if (event.ctrlKey) {
+        const step = 0.05;
+        event.preventDefault();
+        // 阻止事件冒泡
+        event.stopPropagation();
+        const scale = event.detail > 0 ? 1 - step : 1 + step;
+        Array.from(children).forEach((child) => {
+          const childElement = child as HTMLElement;
+          const currentStyle = getChildStyles(child);
+          applyNewStyles(childElement, currentStyle, scale);
+        });
+      }
+    });
+  }
+
   private buildContainer() {
     // 顶层容器
     const container = ztoolkit.UI.createElement(document, "div", {
@@ -775,6 +829,7 @@ export default class Views {
         }
       ]
     }, container) as HTMLDivElement
+    this.bindCtrlScrollZoomOutput(outputContainer)
     // 命令标签
     const tagContainer = this.tagContainer = ztoolkit.UI.appendElement({
       tag: "div",


### PR DESCRIPTION

[测试文件 zotero-gpt.zip](https://github.com/MuiseDestiny/zotero-gpt/files/11187594/zotero-gpt.zip)

目前的缩放针对的是`container`整体，所以为`outputContainer`单独绑定缩放事件，好处是：  
* 可以自由的改变gpt返回结果`outputContainer`的页面内字体大小，而不会同时修改整体的大小
* 有时候返回的markdown表格较宽，目前的缩放无论如何也无法使其不出现水平滚动条

最后的效果就是：  
* 在`outputContainer`元素上就是缩放gpt结果，但不改变整个窗口的大小
* 在`container`的其他部分就是调整窗口大小，也算是比较符合直觉

另外，为什么不直接针对整个`div`设置`font-size`的原因是，`margin`和`padding`的值并不会变化
如果缩小倍数稍多的话，间距显得很大