### PR TITLE
拆分embeddings query为多次请求

### DIFF
--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -9,7 +9,7 @@ pref("extensions.zotero.__addonRef__.width", "32%");
 pref("extensions.zotero.__addonRef__.tagsMore", "expand");
 pref("extensions.zotero.__addonRef__.chatNumber", 3);
 pref("extensions.zotero.__addonRef__.relatedNumber", 5);
-
+pref("extensions.zotero.__addonRef__.embeddingBatchNum", 10);
 
 
 


### PR DESCRIPTION
修改原因：
1、单次请求内容太多容易超时
2、azure的embeddings api不支持多个输入，变通方法是采用cloudflare的worker将一次请求分为多个子请求再拼接返回；但是cloudflare有子请求数量限制(50个)

由于本人没有编译/运行环境，纯手撸了个PR，烦请作者大大review并测试一下
如果这个PRmerge了， 后续我再出一个用 azure api + cloudflare 的文档； 目前其它功能都测试好使，就差这个了