### PR TITLE
fix: Ctrl+S not saving custom tag due to Zotero shortcut interception

### DIFF
--- a/src/modules/views.ts
+++ b/src/modules/views.ts
@@ -473,12 +473,43 @@ export default class Views {
     const textareaNode = inputContainer.querySelector("textarea")!
     const that = this;
     let lastInputText = ""
+
+    // Fix: Ctrl+S may be intercepted by Zotero at the application level before keyup fires.
+    // Handle Ctrl+S and Ctrl+R on keydown with preventDefault() to ensure they always work.
+    textareaNode.addEventListener("keydown", (event: KeyboardEvent) => {
+      if ((event.ctrlKey || event.metaKey) && ["s", "r"].indexOf(event.key) >= 0) {
+        event.preventDefault()
+        event.stopPropagation()
+        const text = textareaNode.value
+        const tag = parseTag(text)
+        if (tag) {
+          textareaNode.value = tag.text
+          let tags = that.getTags()
+          tags = tags.filter((_tag: Tag) => _tag.tag !== tag.tag)
+          tags.push(tag)
+          that.setTags(tags)
+          that.renderTags()
+          if (event.key === "s") {
+            new ztoolkit.ProgressWindow("Save Tag")
+              .createLine({ text: tag.tag, type: "success" })
+              .show()
+          } else if (event.key === "r") {
+            that.execTag(tag)
+          }
+        } else if (event.key === "r") {
+          that.execTag({ tag: "Untitled", position: -1, color: "", trigger: "", text })
+        }
+      }
+    })
+
     let inputListener = function (event: KeyboardEvent) {
       // @ts-ignore
       if(this.style.display == "none") { return }
       // @ts-ignore
       let text = Meet.Global.input = this.value
-      if ((event.ctrlKey || event.metaKey) && ["s", "r"].indexOf(event.key) >= 0 && textareaNode.style.display != "none") {
+      // Ctrl+S and Ctrl+R in textarea are handled by the keydown listener above to prevent
+      // Zotero from intercepting the shortcut before keyup fires.
+      if ((event.ctrlKey || event.metaKey) && ["s", "r"].indexOf(event.key) >= 0 && textareaNode.style.display != "none" && event.target !== textareaNode) {
         // 必定保存，但未必运行
         const tag = parseTag(text)
         if (tag) {


### PR DESCRIPTION
Fixes #489

## Problem

When in tag editing mode (long text textarea), pressing `Ctrl+S` has no response and fails to save the custom tag. The workaround reported by users is to hold `Ctrl+R` until the cursor stops flashing, then release.

The root cause is that `Ctrl+S` is likely intercepted by Zotero at the application/XUL level before the `keyup` event can reach the textarea element. Since the save logic was implemented in a `keyup` listener, it never fires when Zotero captures the keydown event first.

`Ctrl+R` works (via the long-press workaround) because it is not bound to any native Zotero/Firefox action, so the `keyup` event reaches the listener.

## Solution

Move `Ctrl+S` and `Ctrl+R` handling from the `keyup` listener to a `keydown` listener on the textarea element, calling `event.preventDefault()` and `event.stopPropagation()` to intercept the shortcut before Zotero's native handlers.

The `keyup` listener is also updated to skip these shortcuts when the event originates from the textarea (`event.target !== textareaNode`), preventing double-execution.

## Testing

1. Open a Zotero item
2. Open the GPT plugin (Ctrl+/ or Shift+?)
3. Type `#MyTag` and press Enter to enter tag editing mode
4. Add some content to the tag
5. Press `Ctrl+S` — the tag should now be saved with a "Save Tag" success notification
6. Press `Ctrl+R` — the tag should be saved and executed